### PR TITLE
replace pycrypto required lib by pycryptodome

### DIFF
--- a/cipher/__init__.py
+++ b/cipher/__init__.py
@@ -4,4 +4,4 @@ from cipher.fileio import read
 from cipher.fileio import write
 from cipher.credentials import Credentials
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/cipher/cipher.py
+++ b/cipher/cipher.py
@@ -12,7 +12,7 @@ def check_header(raw):
 
 
 def encrypt(passwd, text):
-    padded = pkcs7.pad(text)
+    padded = pkcs7.pad(text).encode()
     salt = os.urandom(8)
     key, iv = derive_password(passwd, salt)
     c = AES.new(key, AES.MODE_CBC, iv)

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,1 +1,1 @@
-pycrypto>=2, <3
+pycryptodome>=3, <4


### PR DESCRIPTION
PyCrypto is no longer maintained.

PyCryptodome is a fork of PyCrypto with some enhancements which has all the same modules under the Crypto package.